### PR TITLE
Endpoint for fetching of all unread received mails

### DIFF
--- a/Server/src/controllers/message.controller.js
+++ b/Server/src/controllers/message.controller.js
@@ -23,26 +23,27 @@ const messageControllers = {
       status: 201,
       data: newMessage
     });
+  },
+
+  findUnreadMessages(req, res) {
+    const unreadMessages = messageServices.findUnreadMessages();
+    return res.json({
+      status: 201,
+      data: unreadMessages
+    });
+  },
+  findAllReceivedMessages(req, res) {
+    const allMessages = messageServices.getAllReceivedMessages();
+    return res.json({
+      status: 201,
+      data: allMessages
+    });
   }
   // findSentMessages(req, res) {
   //   const sentMessage = messageServices.findSentMessages();
   //   return res.json({
   //     status: 201,
   //     data: sentMessage
-  //   });
-  // },
-  // findUnreadMessages(req, res) {
-  //   const unreadMessages = messageServices.findUnreadMessages();
-  //   return res.json({
-  //     status: 201,
-  //     data: unreadMessages
-  //   });
-  // },
-  // findAllReceivedMessages(req, res) {
-  //   const allMessages = messageServices.getAllReceivedMessages();
-  //   return res.json({
-  //     status: 201,
-  //     data: allMessages
   //   });
   // },
   // getOneMessage(req, res) {

--- a/Server/src/routes/message.router.js
+++ b/Server/src/routes/message.router.js
@@ -4,8 +4,8 @@ import messageControllers from '../controllers/message.controller';
 const router = Router();
 
 router.post('/', messageControllers.createMessage);
-// router.get('/', messageControllers.findAllReceivedMessages);
-// router.get('/unread', messageControllers.findUnreadMessages);
+router.get('/', messageControllers.findAllReceivedMessages);
+router.get('/unread', messageControllers.findUnreadMessages);
 // router.get('/sent', messageControllers.findSentMessages);
 // router.get('/:id', messageControllers.getOneMessage);
 // router.delete('/:id', messageControllers.deleteMessage);

--- a/Server/src/services/message.services.js
+++ b/Server/src/services/message.services.js
@@ -17,28 +17,28 @@ const messageServices = {
     messageObj.createdOn = today;
     messageArr.push(messageObj);
     return messageObj;
-  }
+  },
 
   // findSentMessages() {
   //   const messageArr = allData.messages;
   //   const sentMessages = messageArr.filter(each => each.status === 'sent');
   //   return sentMessages;
   // },
-  // findUnreadMessages() {
-  //   const messageArr = allData.messages;
-  //   const unreadMessages = messageArr.filter(each => each.status === 'unread');
-  //   return unreadMessages;
-  // },
+  findUnreadMessages() {
+    const messageArr = allData.messages;
+    const unreadMessages = messageArr.filter(each => each.status === 'unread');
+    return unreadMessages;
+  },
 
-  // getAllReceivedMessages() {
-  //   const messageArr = allData.messages;
-  //   const receivedMessages = messageArr.filter((each) => {
-  //     if (each.status === 'read' || each.status === 'unread') {
-  //       return each;
-  //     }
-  //   });
-  //   return [...receivedMessages];
-  // },
+  getAllReceivedMessages() {
+    const messageArr = allData.messages;
+    const receivedMessages = messageArr.filter((each) => {
+      if (each.status === 'read' || each.status === 'unread') {
+        return each;
+      }
+    });
+    return [...receivedMessages];
+  }
 
   // getOneMessage(id) {
   //   const messageArr = allData.messages;

--- a/Server/test/server.test.js
+++ b/Server/test/server.test.js
@@ -66,49 +66,49 @@ describe('Testing endpoints', () => {
   });
 });
 
-// describe('Creating and Testing API endpoints', () => {
-//   it('it  should return specific keys "allMessages and Status" when a call is made to all received messages', (done) => {
-//     chai.request(server)
-//       .get('/api/v1/messages')
-//       .end((err, res) => {
-//         if (err) {
-//           done(err);
-//         }
-//         expect(res.body).to.have.keys('status', 'data');
-//         expect(res.body).to.have.ownProperty('status').that.equals(201);
-//         expect(res.body).to.have.ownProperty('data').to.be.an('array');
-//         expect(res.body.data[0].subject).to.be.a('string');
-//         expect(res.body.data[0].message).to.be.a('string');
-//         expect(res.body.data[0].id).to.be.a('number');
-//         expect(res.body.data[0].status).to.be.a('string');
-//         expect(res.body.data[0].parentMessageId).to.be.a('number');
-//         done();
-//       });
-//   });
-// });
+describe('Creating and Testing API endpoints', () => {
+  it('it  should return specific keys "allMessages and Status" when a call is made to all received messages', (done) => {
+    chai.request(server)
+      .get('/api/v1/messages')
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.body).to.have.ownProperty('status').that.equals(201);
+        expect(res.body).to.have.ownProperty('data').to.be.an('array');
+        expect(res.body.data[0].subject).to.be.a('string');
+        expect(res.body.data[0].message).to.be.a('string');
+        expect(res.body.data[0].id).to.be.a('number');
+        expect(res.body.data[0].status).to.be.a('string');
+        expect(res.body.data[0].parentMessageId).to.be.a('number');
+        done();
+      });
+  });
+});
 
 
-// describe('Fetching all unread Messages', () => {
-//   it('it  should return specific value:UNREAD when a call is made to all received unread messages', (done) => {
-//     chai.request(server)
-//       .get('/api/v1/messages/unread')
-//       .end((err, res) => {
-//         if (err) {
-//           done(err);
-//         }
-//         expect(res.body).to.have.keys('status', 'data');
-//         expect(res.body).to.have.ownProperty('status').that.equals(201);
-//         expect(res.body).to.have.ownProperty('data').to.be.an('array');
-//         expect(res.body.data[0].subject).to.be.a('string');
-//         expect(res.body.data[0].message).to.be.a('string');
-//         expect(res.body.data[0].id).to.be.a('number');
-//         expect(res.body.data[0].status).to.be.a('string');
-//         expect(res.body.data[0].status).to.equal('unread');
-//         expect(res.body.data[0].parentMessageId).to.be.a('number');
-//         done();
-//       });
-//   });
-// });
+describe('Fetching all unread Messages', () => {
+  it('it  should return specific value:UNREAD when a call is made to all received unread messages', (done) => {
+    chai.request(server)
+      .get('/api/v1/messages/unread')
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.body).to.have.ownProperty('status').that.equals(201);
+        expect(res.body).to.have.ownProperty('data').to.be.an('array');
+        expect(res.body.data[0].subject).to.be.a('string');
+        expect(res.body.data[0].message).to.be.a('string');
+        expect(res.body.data[0].id).to.be.a('number');
+        expect(res.body.data[0].status).to.be.a('string');
+        expect(res.body.data[0].status).to.equal('unread');
+        expect(res.body.data[0].parentMessageId).to.be.a('number');
+        done();
+      });
+  });
+});
 // describe('Fetching all sent Messages', () => {
 //   it('it  should return specific value:SENT when a call is made to all sent messages', (done) => {
 //     chai.request(server)


### PR DESCRIPTION
#### Implement Endpoint for fetching unread received messages
Built an endpoint that allows a user to fetch all unread received messages still stored in the database, 

#### Tasks
- used methods in implementing this function

#### Pivotal Tracker Link : https://www.pivotaltracker.com/story/show/164525403

#### Testing
The endpoint was tested using Postman, Mocha Test suite and Chai assertion Library
